### PR TITLE
Can't launch .js if it has non-default association

### DIFF
--- a/install-mingw.bat
+++ b/install-mingw.bat
@@ -1,2 +1,2 @@
 @echo off
-cscript install-mingw.js
+cscript //E:jscript install-mingw.js


### PR DESCRIPTION
cscript on w7x64 for some reason fails to launch a javascript file if a user has reassociated .js extension. Adding an extra parameter fixes it.
See here: http://stackoverflow.com/questions/7189269/running-javascript-with-cscript
