### PR TITLE
Fixed incorrect calls to copy.exe

### DIFF
--- a/install-mingw.bat
+++ b/install-mingw.bat
@@ -1,6 +1,6 @@
 @echo off
 cscript //E:jscript install-mingw.js %*
 pushd bin
-if not exist cc.exe copy /B cc.exe gcc.exe
-if not exist mingw32-cc.exe copy /B mingw32-cc.exe mingw32-gcc.exe
+if not exist cc.exe copy /B gcc.exe cc.exe
+if not exist mingw32-cc.exe copy /B mingw32-gcc.exe mingw32-cc.exe
 popd bin


### PR DESCRIPTION
The `install-mingw.bat` script calls copy.exe with the wrong order of the arguments:

The correct order is `copy [SOURCE] [DESTINATION]`, but the script calls it expecting `copy [DESTINATION] [SOURCE]`.
